### PR TITLE
Adicionar botão Agrupar/Desagrupar nas DMs

### DIFF
--- a/client/src/pages/queue.tsx
+++ b/client/src/pages/queue.tsx
@@ -48,6 +48,7 @@ export default function Queue({ defaultFilter = "all" }: QueueProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [typeFilter, setTypeFilter] = useState<"all" | "dm" | "comment">(defaultFilter);
   const [viewMode, setViewMode] = useState<"grouped" | "list">("grouped");
+  const [dmViewMode, setDmViewMode] = useState<"grouped" | "list">("grouped");
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
@@ -284,9 +285,13 @@ export default function Queue({ defaultFilter = "all" }: QueueProps) {
       }
     });
 
+    const sortedDms = [...dms].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
     return {
       postGroups: Array.from(groupedByPost.values()),
-      dmMessages: dms,
+      dmMessages: sortedDms,
       dmConversations: dmGroups,
       ungroupedComments: ungrouped,
     };
@@ -404,58 +409,91 @@ export default function Queue({ defaultFilter = "all" }: QueueProps) {
               {dmMessages.length > 0 && (
                 <div className="space-y-4" data-testid="section-dms">
                   <div className="border-b pb-3">
-                    <div className="flex items-center gap-2">
-                      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
-                        <MessageSquare className="h-4 w-4 text-primary" />
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="flex items-center gap-2">
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
+                          <MessageSquare className="h-4 w-4 text-primary" />
+                        </div>
+                        <div>
+                          <h2 className="text-base font-semibold flex items-center gap-2">
+                            Mensagens Diretas
+                            <span className="text-sm font-normal text-muted-foreground">
+                              ({dmMessages.length})
+                            </span>
+                          </h2>
+                          <p className="text-sm text-muted-foreground">
+                            Mensagens privadas recebidas no Instagram Direct
+                          </p>
+                        </div>
                       </div>
-                      <div>
-                        <h2 className="text-base font-semibold flex items-center gap-2">
-                          Mensagens Diretas
-                          <span className="text-sm font-normal text-muted-foreground">
-                            ({dmMessages.length})
-                          </span>
-                        </h2>
-                        <p className="text-sm text-muted-foreground">
-                          Mensagens privadas recebidas no Instagram Direct
-                        </p>
+                      <div className="flex items-center border rounded-md">
+                        <Button
+                          variant={dmViewMode === "grouped" ? "default" : "ghost"}
+                          size="sm"
+                          onClick={() => setDmViewMode("grouped")}
+                          className="rounded-r-none"
+                          data-testid="button-dm-view-grouped"
+                        >
+                          <LayoutGrid className="h-4 w-4 mr-1" />
+                          Agrupar
+                        </Button>
+                        <Button
+                          variant={dmViewMode === "list" ? "default" : "ghost"}
+                          size="sm"
+                          onClick={() => setDmViewMode("list")}
+                          className="rounded-l-none"
+                          data-testid="button-dm-view-list"
+                        >
+                          <List className="h-4 w-4 mr-1" />
+                          Desagrupar
+                        </Button>
                       </div>
                     </div>
                   </div>
                   <div className="space-y-4">
-                    {dmConversations.map((conversation) => (
-                      <div
-                        key={conversation.senderUsername || conversation.senderName}
-                        className="space-y-3 rounded-lg border p-4"
-                        data-testid={`dm-group-${conversation.senderUsername || conversation.senderName}`}
-                      >
-                        <div className="flex items-center gap-3">
-                          <Avatar className="h-9 w-9 border">
-                            <AvatarImage src={conversation.senderAvatar || undefined} />
-                            <AvatarFallback>
-                              {getInitials(conversation.senderName)}
-                            </AvatarFallback>
-                          </Avatar>
-                          <div>
-                            <p className="text-sm font-semibold">
-                              {conversation.senderName}
-                            </p>
-                            <p className="text-xs text-muted-foreground">
-                              @{conversation.senderUsername || "usuario"} · {conversation.messageCount}{" "}
-                              mensagem{conversation.messageCount === 1 ? "" : "s"}
-                            </p>
+                    {dmViewMode === "grouped"
+                      ? dmConversations.map((conversation) => (
+                          <div
+                            key={conversation.senderUsername || conversation.senderName}
+                            className="space-y-3 rounded-lg border p-4"
+                            data-testid={`dm-group-${conversation.senderUsername || conversation.senderName}`}
+                          >
+                            <div className="flex items-center gap-3">
+                              <Avatar className="h-9 w-9 border">
+                                <AvatarImage src={conversation.senderAvatar || undefined} />
+                                <AvatarFallback>
+                                  {getInitials(conversation.senderName)}
+                                </AvatarFallback>
+                              </Avatar>
+                              <div>
+                                <p className="text-sm font-semibold">
+                                  {conversation.senderName}
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                  @{conversation.senderUsername || "usuario"} ·{" "}
+                                  {conversation.messageCount} mensagem
+                                  {conversation.messageCount === 1 ? "" : "s"}
+                                </p>
+                              </div>
+                            </div>
+                            <div className="space-y-3">
+                              {conversation.messages.map((message) => (
+                                <MessageCard
+                                  key={message.id}
+                                  message={message}
+                                  onView={handleViewMessage}
+                                />
+                              ))}
+                            </div>
                           </div>
-                        </div>
-                        <div className="space-y-3">
-                          {conversation.messages.map((message) => (
-                            <MessageCard
-                              key={message.id}
-                              message={message}
-                              onView={handleViewMessage}
-                            />
-                          ))}
-                        </div>
-                      </div>
-                    ))}
+                        ))
+                      : dmMessages.map((message) => (
+                          <MessageCard
+                            key={message.id}
+                            message={message}
+                            onView={handleViewMessage}
+                          />
+                        ))}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
### Motivation
- Permitir ao usuário alternar entre visualização agrupada por conversa e lista plana nas Mensagens Diretas para facilitar revisão. 
- Garantir que a lista plana de DMs mostre mensagens em ordem de recência para priorizar itens mais novos. 

### Description
- Added a new state `dmViewMode` with values `"grouped" | "list"` and buttons to toggle it inside the DMs section in `client/src/pages/queue.tsx`.
- Implemented conditional rendering so the DMs area shows either grouped conversations (`dmConversations`) or a flat list (`dmMessages`) based on `dmViewMode`.
- Sorted ungrouped DM messages by most recent with `const sortedDms = [...dms].sort(...)` and returned them as `dmMessages` in the memoized grouping logic.
- Adjusted the DMs header layout and added `data-testid` attributes `button-dm-view-grouped` and `button-dm-view-list` to the new control buttons for testing.

### Testing
- Attempted to start the dev server with `npm run dev`, but it failed to run end-to-end in this environment due to a missing `DATABASE_URL` configuration (failure).
- Attempted to capture a UI screenshot via Playwright to validate the new buttons, but the browser process crashed in the environment (failure).
- No automated unit or integration tests were added or executed for this change (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697666b4303483258796623b816b9f75)