### PR TITLE
Fix Instagram links redirection and enable spellcheck

### DIFF
--- a/client/src/components/approval-modal.tsx
+++ b/client/src/components/approval-modal.tsx
@@ -174,7 +174,7 @@ export function ApprovalModal({
                 )}
                 {message.type === "dm" ? "Mensagem Direta" : "Comentário no Post"}
               </h3>
-              {message.type === "comment" && message.postPermalink && (
+              {message.type === "comment" && message.postPermalink && (message.postPermalink.includes("/p/") || message.postPermalink.includes("/reel/") || message.postPermalink.includes("/tv/")) && (
                 <a
                   href={message.postPermalink}
                   target="_blank"
@@ -317,6 +317,8 @@ export function ApprovalModal({
                   placeholder={hasAIError ? "Escreva sua resposta aqui..." : "Resposta sugerida pela IA..."}
                   className="h-full min-h-[200px] resize-none"
                   disabled={!isEditing && !isLoading}
+                  spellCheck={true}
+                  lang="pt-BR"
                   data-testid="textarea-response"
                 />
                 {wasEdited && (

--- a/client/src/components/post-comment-group.tsx
+++ b/client/src/components/post-comment-group.tsx
@@ -109,7 +109,7 @@ export function PostCommentGroup({
                   <MessageCircle className="h-3 w-3 mr-1" />
                   {comments.length} {comments.length === 1 ? 'comentário' : 'comentários'}
                 </Badge>
-                {postPermalink && (
+                {postPermalink && (postPermalink.includes("/p/") || postPermalink.includes("/reel/") || postPermalink.includes("/tv/")) && (
                   <a
                     href={postPermalink}
                     target="_blank"


### PR DESCRIPTION
This change fixes two issues reported by the user:
1.  **Broken Instagram Links:** The "Ver post no Instagram" link was redirecting to the homepage. This was caused by potentially incomplete or root URLs being rendered. I added validation to ensure the link contains `/p/`, `/reel/`, or `/tv/` before rendering it.
2.  **Missing Spellcheck:** The response editing box did not have spellcheck enabled. I explicitly added `spellCheck={true}` and `lang="pt-BR"`.

---
*PR created automatically by Jules for task [6923813872805093603](https://jules.google.com/task/6923813872805093603) started by @gustavorubino*