### PR TITLE
feat: migrate legacy learning history to user dataset

### DIFF
--- a/client/src/pages/brain/dataset.tsx
+++ b/client/src/pages/brain/dataset.tsx
@@ -91,6 +91,23 @@ export default function Dataset() {
     },
   });
 
+  const migrateMutation = useMutation({
+    mutationFn: async () => {
+      const res = await apiRequest("POST", "/api/brain/migrate-legacy");
+      return res.json();
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/brain/dataset"] });
+      toast({
+        title: "Migração Concluída",
+        description: `Importados: ${data.migrated}, Ignorados (duplicados): ${data.skipped}, Erros: ${data.errors}`
+      });
+    },
+    onError: () => {
+      toast({ title: "Erro", description: "Falha ao importar histórico antigo.", variant: "destructive" });
+    },
+  });
+
   const handleSubmit = () => {
     if (!formData.question.trim() || !formData.answer.trim()) return;
 
@@ -128,10 +145,16 @@ export default function Dataset() {
             Gerencie os exemplos de Perguntas e Respostas que guiam a IA (Few-Shot Learning).
           </p>
         </div>
-        <Button onClick={openCreateDialog}>
-          <Plus className="h-4 w-4 mr-2" />
-          Adicionar Exemplo
-        </Button>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => migrateMutation.mutate()} disabled={migrateMutation.isPending}>
+            {migrateMutation.isPending ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : null}
+            Importar Histórico Antigo
+          </Button>
+          <Button onClick={openCreateDialog}>
+            <Plus className="h-4 w-4 mr-2" />
+            Adicionar Exemplo
+          </Button>
+        </div>
       </div>
 
       <Card>


### PR DESCRIPTION
Implemented data migration and future-proofing for AI learning history.
1.  **Future-proofing**: When a user edits and approves an AI response, it is now saved directly to their personal `aiDataset` (with embeddings generated) in addition to the legacy log. This ensures new learnings appear immediately in the "Memory & Dataset" page.
2.  **Migration**: Created a new endpoint and UI button to migrate old "Learning History" records (which were previously global/hidden) into the user's active Dataset. This recovers past corrections so they can be edited, deleted, and used for future AI context (RAG).

---
*PR created automatically by Jules for task [17115159565681314851](https://jules.google.com/task/17115159565681314851) started by @gustavorubino*