### PR TITLE
Fix pending message count inconsistency across UI components

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -623,8 +623,8 @@ export async function registerRoutes(
   // Get dashboard stats
   app.get("/api/stats", isAuthenticated, async (req, res) => {
     try {
-      const { userId, isAdmin } = await getUserContext(req);
-      const stats = await storage.getStats(userId, isAdmin);
+      const { userId, isAdmin, excludeSenderIds, excludeSenderUsernames } = await getUserContext(req);
+      const stats = await storage.getStats(userId, isAdmin, excludeSenderIds, excludeSenderUsernames);
       res.json(stats);
     } catch (error) {
       console.error("Error fetching stats:", error);
@@ -4817,7 +4817,7 @@ export async function registerRoutes(
       }
 
       if (currentMode === "copilot") {
-        const response = await runCopilotAgent(history || []);
+        const response = await runCopilotAgent(history || [], userId);
         return res.json({ response, confidence: 1.0 });
       }
 


### PR DESCRIPTION
This change addresses the inconsistency in pending message counts displayed in the Sidebar, Dashboard Widget, and Copilot. 

It centralizes the counting logic into a new `getPendingMessagesCount` function in the backend storage, which applies standard filters:
1.  Status = 'PENDING'
2.  Excludes messages from the user's own accounts (via `instagramAccountId`, `instagramRecipientId`, and `instagramUsername`).

All three components now consume this single source of truth (directly or via `getStats`), ensuring the numbers match exactly.

---
*PR created automatically by Jules for task [16348433273537008315](https://jules.google.com/task/16348433273537008315) started by @gustavorubino*