### PR TITLE
Fix OpenAI image payload handling and add debugging

### DIFF
--- a/client/src/pages/brain/trainer.tsx
+++ b/client/src/pages/brain/trainer.tsx
@@ -182,6 +182,11 @@ export default function Trainer() {
 
     const newHistory = [...messages, userMsg];
     setMessages(newHistory);
+
+    if (attachments.length > 0) {
+      console.log(`Sending ${attachments.length} attachments. Sample:`, attachments[0].substring(0, 50) + "...");
+    }
+
     simulateMutation.mutate({
         message: inputValue,
         history: newHistory,


### PR DESCRIPTION
Modified server/openai.ts to validate image attachments, automatically adding the data URI prefix if missing, and improved logging to debug payload issues. Added verification logs to client/src/pages/brain/trainer.tsx to confirm frontend payload structure.

---
*PR created automatically by Jules for task [1753260997732818506](https://jules.google.com/task/1753260997732818506) started by @gustavorubino*