### PR TITLE
fix: restrict legacy migration to admin in multi-user setups

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4693,7 +4693,13 @@ export async function registerRoutes(
   // POST /api/brain/migrate-legacy - Migrate learning history to dataset
   app.post("/api/brain/migrate-legacy", isAuthenticated, async (req, res) => {
     try {
-      const { userId } = await getUserContext(req);
+      const { userId, isAdmin } = await getUserContext(req);
+      const users = await authStorage.getAllUsers();
+      if (!isAdmin && users.length > 1) {
+        return res.status(403).json({
+          error: "Admin access required to migrate legacy data in multi-user setups",
+        });
+      }
 
       console.log(`[Migration] Starting legacy learning migration for user ${userId}...`);
 


### PR DESCRIPTION
### Motivation
- The legacy migration endpoint used `getLearningHistory()` (a global table without `user_id`) and could import other users' corrections into the current user's dataset in multi-tenant environments, so the flow must be gated to prevent cross-tenant data exposure.

### Description
- Added a guard in `POST /api/brain/migrate-legacy` to fetch `{ userId, isAdmin }` via `getUserContext`, call `authStorage.getAllUsers()`, and return `403` for non-admins when more than one user exists; change is in `server/routes.ts` and limits migration to admins in multi-user setups.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b93fe922c83259601f881cb172b13)