### PR TITLE
⚡ Performance: Optimize Dataset Cleanup with Batch Delete

### DIFF
--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -4858,15 +4858,7 @@ export async function registerRoutes(
         "Qual sua opinião sobre isso?"
       ];
 
-      const dataset = await storage.getDataset(userId);
-      let deletedCount = 0;
-
-      for (const entry of dataset) {
-        if (genericQuestions.includes(entry.question)) {
-          await storage.deleteDatasetEntry(entry.id, userId);
-          deletedCount++;
-        }
-      }
+      const deletedCount = await storage.deleteDatasetEntriesByQuestions(genericQuestions, userId);
 
       console.log(`[Dataset Cleanup] ✅ Removidos ${deletedCount} registros genéricos para userId: ${userId}`);
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -122,6 +122,7 @@ export interface IStorage {
   addDatasetEntry(entry: InsertAiDatasetEntry): Promise<AiDatasetEntry>;
   updateDatasetEntry(id: number, userId: string, entry: Partial<InsertAiDatasetEntry>): Promise<AiDatasetEntry | undefined>;
   deleteDatasetEntry(id: number, userId: string): Promise<void>;
+  deleteDatasetEntriesByQuestions(questions: string[], userId: string): Promise<number>;
 
   // Instagram Profiles
   getInstagramProfiles(userId: string): Promise<InstagramProfile[]>;
@@ -942,6 +943,20 @@ export class DatabaseStorage implements IStorage {
     await db
       .delete(aiDataset)
       .where(and(eq(aiDataset.id, id), eq(aiDataset.userId, userId)));
+  }
+
+  async deleteDatasetEntriesByQuestions(questions: string[], userId: string): Promise<number> {
+    if (questions.length === 0) return 0;
+
+    const result = await db
+      .delete(aiDataset)
+      .where(and(
+        eq(aiDataset.userId, userId),
+        inArray(aiDataset.question, questions)
+      ))
+      .returning({ id: aiDataset.id });
+
+    return result.length;
   }
 
   // Instagram Profiles


### PR DESCRIPTION
This PR addresses a performance issue in the dataset cleanup process where entries were being deleted one by one in a loop (N+1 query problem).

**Changes:**
1.  **`server/storage.ts`**: Added `deleteDatasetEntriesByQuestions` method to `IStorage` interface and `DatabaseStorage` class. This method uses Drizzle ORM's `inArray` to perform a single `DELETE` query for all matching questions for a specific user.
2.  **`server/routes/index.ts`**: Refactored the `DELETE /api/knowledge/dataset/cleanup` endpoint to replace the iteration loop with a call to the new batch delete method.

**Performance Impact:**
- **Baseline:** Previously, deleting N entries required 1 fetch query + N delete queries.
- **Improvement:** Now requires only 1 delete query. This significantly reduces database round trips and overhead, especially as the dataset grows.

**Verification:**
- Verified TypeScript compilation with `npm run check`.
- Verified logic correctness (imports, types, query structure).
- Attempted benchmarking but was limited by the lack of a live database connection in the environment; however, the theoretical benefit of O(1) query count vs O(N) is indisputable for this pattern.

---
*PR created automatically by Jules for task [14352703436799907085](https://jules.google.com/task/14352703436799907085) started by @gustavorubino*