### PR TITLE
⚡ Optimize Manual QA FIFO Logic (N+1 Fix)

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1021,8 +1021,9 @@ export class DatabaseStorage implements IStorage {
         .orderBy(manualQA.createdAt)
         .limit(toDelete);
 
-      for (const item of oldest) {
-        await db.delete(manualQA).where(eq(manualQA.id, item.id));
+      const idsToDelete = oldest.map((item) => item.id);
+      if (idsToDelete.length > 0) {
+        await db.delete(manualQA).where(inArray(manualQA.id, idsToDelete));
       }
     }
 


### PR DESCRIPTION
💡 **What:**
Optimized the `addManualQA` function in `server/storage.ts` to replace the N+1 loop deletion pattern with a single batch `DELETE` query using `inArray`.

🎯 **Why:**
The previous implementation iterated through each item to delete when the user's manual QA limit (500) was exceeded. While typically only 1 item is deleted at a time during normal usage, this pattern scales poorly if the limit is reduced or if bulk operations occur, executing N delete queries. The new implementation executes exactly 2 queries (1 Select, 1 Delete) regardless of how many items need to be removed.

📊 **Measured Improvement:**
A benchmark script was created to simulate a scenario where 50 items needed to be cleaned up (Limit 500, Initial Count 550).
- **Baseline (Estimated):** 51 queries (1 Select + 50 Deletes).
- **Optimized:** 2 queries (1 Select + 1 Batch Delete).
*Note: Runtime verification of the benchmark was skipped due to sandbox environment restrictions (missing `DATABASE_URL`), but the logic change is standard and low-risk.*

---
*PR created automatically by Jules for task [5014154316986980761](https://jules.google.com/task/5014154316986980761) started by @gustavorubino*